### PR TITLE
Update poly fit to work with scipy 0.18.0

### DIFF
--- a/scikits/fitting/poly.py
+++ b/scikits/fitting/poly.py
@@ -482,9 +482,12 @@ class PiecewisePolynomial1DFit(ScatterFit):
             self._poly = lambda new_x: _linear_interp(x, y, np.asarray(new_x))
         else:
             try:
-                self._poly = scipy.interpolate.PiecewisePolynomial(x, y_list, orders=None, direction=1)
+                self._poly = scipy.interpolate.BPoly.from_derivatives(x, y_list, orders=None)
             except AttributeError:
-                raise ImportError("SciPy 0.7.0 or newer needed for higher-order piecewise polynomials")
+                try:
+                    self._poly = scipy.interpolate.PiecewisePolynomial(x, y_list, orders=None, direction=1)
+                except AttributeError:
+                    raise ImportError("SciPy 0.7.0 or newer needed for higher-order piecewise polynomials")
         return self
 
     def __call__(self, x):


### PR DESCRIPTION
Update PiecewisePolynomial1DFit to work with scipy 0.18.0 and up, which
has finally replaced PiecewisePolynomial with PPoly and BPoly, as
threatened since 0.14.0. Use the suggested drop-in replacement in the
release notes for now.