### PR TITLE
Remove nose-related function

### DIFF
--- a/scikits/fitting/tests/test_delaunay.py
+++ b/scikits/fitting/tests/test_delaunay.py
@@ -22,7 +22,7 @@
 """
 
 import numpy as np
-from numpy.testing import TestCase, assert_almost_equal, run_module_suite
+from numpy.testing import TestCase, assert_almost_equal
 
 from scikits.fitting import Delaunay2DScatterFit, NotFittedError
 
@@ -80,7 +80,3 @@ class TestDelaunay2DScatterFit(TestCase):
         assert_almost_equal(testy, self.testy, decimal=10)
         # Nearest-neighbour interpolation has no outside value
         # assert_almost_equal(outsidey, self.outsidey, decimal=10)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scikits/fitting/tests/test_gaussian.py
+++ b/scikits/fitting/tests/test_gaussian.py
@@ -24,7 +24,7 @@ from __future__ import division
 
 from builtins import range
 import numpy as np
-from numpy.testing import TestCase, assert_almost_equal, run_module_suite
+from numpy.testing import TestCase, assert_almost_equal
 
 from scikits.fitting import GaussianFit
 
@@ -131,7 +131,3 @@ class TestGaussianFitDegenerate(TestCase):
         assert_almost_equal(interp.std, self.true_std, decimal=7)
         assert_almost_equal(interp.height, self.true_height, decimal=7)
         assert_almost_equal(y, self.y, decimal=7)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scikits/fitting/tests/test_generic.py
+++ b/scikits/fitting/tests/test_generic.py
@@ -22,7 +22,7 @@
 """
 
 import numpy as np
-from numpy.testing import TestCase, assert_almost_equal, run_module_suite
+from numpy.testing import TestCase, assert_almost_equal
 
 from scikits.fitting import Independent1DFit, Polynomial1DFit, NotFittedError
 
@@ -62,7 +62,3 @@ class TestIndependent1DFit(TestCase):
         assert_almost_equal(interp._interps[1, 1].poly, self.poly1, decimal=10)
         assert_almost_equal(interp._interps[1, 2].poly, self.poly2, decimal=10)
         assert_almost_equal(y, self.y, decimal=10)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scikits/fitting/tests/test_linlstsq.py
+++ b/scikits/fitting/tests/test_linlstsq.py
@@ -26,8 +26,7 @@ import warnings
 
 from builtins import range
 import numpy as np
-from numpy.testing import (TestCase, assert_equal, assert_almost_equal,
-                           run_module_suite)
+from numpy.testing import TestCase, assert_equal, assert_almost_equal
 
 from scikits.fitting import LinearLeastSquaresFit, NotFittedError
 
@@ -89,7 +88,3 @@ class TestLinearLeastSquaresFit(TestCase):
                          "Least-squares fit may be poorly conditioned")
         params = np.linalg.lstsq(self.poly_x.T, self.poly_y, rcond)[0]
         assert_almost_equal(interp.params, params, decimal=10)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scikits/fitting/tests/test_nonlinlstsq.py
+++ b/scikits/fitting/tests/test_nonlinlstsq.py
@@ -23,7 +23,7 @@
 from __future__ import division
 
 import numpy as np
-from numpy.testing import TestCase, assert_almost_equal, run_module_suite
+from numpy.testing import TestCase, assert_almost_equal
 
 from scikits.fitting import (NonLinearLeastSquaresFit, LinearLeastSquaresFit,
                              vectorize_fit_func)
@@ -109,7 +109,3 @@ class TestNonLinearLeastSquaresFit(TestCase):
         nonlin.fit(self.x3, self.y3, std_y=2.0)
         assert_almost_equal(nonlin.params, self.true_params3, decimal=11)
         assert_almost_equal(nonlin.cov_params, lin_cov_params, decimal=11)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scikits/fitting/tests/test_poly.py
+++ b/scikits/fitting/tests/test_poly.py
@@ -24,8 +24,7 @@ from __future__ import division
 
 from builtins import range
 import numpy as np
-from numpy.testing import (TestCase, assert_equal, assert_almost_equal,
-                           run_module_suite)
+from numpy.testing import TestCase, assert_equal, assert_almost_equal
 
 from scikits.fitting import (Polynomial1DFit, Polynomial2DFit,
                              PiecewisePolynomial1DFit, NotFittedError)
@@ -224,7 +223,3 @@ class TestPiecewisePolynomial1DFit(TestCase):
         assert_almost_equal(_linear_interp(x, y, x), y, decimal=10)
         assert_almost_equal(interp(self.x), _linear_interp(x, y, self.x),
                             decimal=10)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scikits/fitting/tests/test_rbf.py
+++ b/scikits/fitting/tests/test_rbf.py
@@ -22,7 +22,7 @@
 """
 
 import numpy as np
-from numpy.testing import TestCase, assert_almost_equal, run_module_suite
+from numpy.testing import TestCase, assert_almost_equal
 
 from scikits.fitting import RbfScatterFit, NotFittedError
 
@@ -47,7 +47,3 @@ class TestRbfScatterFit(TestCase):
         testy = interp(self.testx)
         assert_almost_equal(y, self.y, decimal=10)
         assert_almost_equal(testy, self.testy, decimal=2)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scikits/fitting/tests/test_spline.py
+++ b/scikits/fitting/tests/test_spline.py
@@ -24,7 +24,7 @@ from __future__ import division
 
 from builtins import range
 import numpy as np
-from numpy.testing import TestCase, assert_almost_equal, run_module_suite
+from numpy.testing import TestCase, assert_almost_equal
 
 from scikits.fitting import (Spline1DFit, Spline2DScatterFit, Spline2DGridFit,
                              NotFittedError)
@@ -141,7 +141,3 @@ class TestSpline2DGridFit(TestCase):
         rel_std_diff_p90 = sorted(rel_std_diff.ravel())[
             int(0.90 * rel_std_diff.size)]
         self.assertTrue(rel_std_diff_p90 < 0.1)
-
-
-if __name__ == "__main__":
-    run_module_suite()

--- a/scikits/fitting/tests/test_utils.py
+++ b/scikits/fitting/tests/test_utils.py
@@ -23,8 +23,7 @@
 
 from builtins import range
 import numpy as np
-from numpy.testing import (TestCase, assert_array_equal, assert_almost_equal,
-                           run_module_suite)
+from numpy.testing import TestCase, assert_array_equal, assert_almost_equal
 
 from scikits.fitting import squash, unsquash, randomise, Polynomial1DFit
 
@@ -108,7 +107,3 @@ class TestRandomise(TestCase):
         assert_almost_equal(boot_poly.mean(axis=0), noisy_poly[0], decimal=2)
         assert_almost_equal(boot_poly.std(axis=0), noisy_poly.std(axis=0),
                             decimal=2)
-
-
-if __name__ == "__main__":
-    run_module_suite()


### PR DESCRIPTION
The `run_module_suite` function is a leftover from the defunct nose support that was removed in NumPy 1.25. Use pytest instead.